### PR TITLE
Set up CI for PR tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Test
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+      - run: bundle exec rake


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `bundle exec rake` on pull requests

## Testing
- `bundle exec rake` *(fails: `bundle: command not found`)*